### PR TITLE
common: move tcmiface config to our vendor

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -12,10 +12,6 @@ include device/qcom/common/utils.mk
 
 TARGET_CRYPTFS_HW_PATH := device/qcom/common/cryptfs_hw
 
-# Dummy DPM controller to hook into http
-PRODUCT_PACKAGES += tcmiface
-PRODUCT_BOOT_JARS += tcmiface
-
 # Advanced DPM
 ifeq ($(TARGET_WANTS_EXTENDED_DPM_PLATFORM),true)
 PRODUCT_BOOT_JARS += tcmclient


### PR DESCRIPTION
This is actually needed for non-qcom devices as well, otherwise
the bootclasspath breaks because numerous components
depend on the tcm extensions right now.

Change-Id: I7ca017c3b573c7b2c9760a71513b149df085f6b8
Signed-off-by: Alex Naidis <alex.naidis@linux.com>